### PR TITLE
Unlock Doors fix when not host

### DIFF
--- a/DevourClient/Hacks/Unlock.cs
+++ b/DevourClient/Hacks/Unlock.cs
@@ -39,6 +39,15 @@
             //Pour chaques portes, on les ouvre
             foreach (Horror.DoorBehaviour doorBehaviour in UnityEngine.Object.FindObjectsOfType<Horror.DoorBehaviour>())
             {
+                doorBehaviour.state.Locked = false;
+                if (doorBehaviour.IsOpen())
+                {
+                    doorBehaviour.m_DoorGraphUpdate.DoorOpening();
+                }
+                else
+                {
+                    doorBehaviour.m_DoorGraphUpdate.DoorClosed();
+                }
                 doorBehaviour.Unlock();
             }
         }


### PR DESCRIPTION
The problem was that this check failed 
<details>
 <summary>Screenshot</summary>

![image](https://user-images.githubusercontent.com/49619526/168337396-954e1a80-f2fd-41cf-b0cf-b325d5e8a686.png)

</details>
so I just copied the code...