### PR TITLE
Temp fix for random crashes during the game while using ESP

### DIFF
--- a/user/features/esp/esp.hpp
+++ b/user/features/esp/esp.hpp
@@ -2,7 +2,19 @@
 
 #include "settings/settings.hpp"
 
+
+
 namespace ESP {
+	// TEMP FIX #60
+	inline app::GameObject__Array* ents_azazel = NULL;
+	inline app::Object_1__Array* ents_item;
+	inline app::Object_1__Array* ents_goat;
+
+	inline int time_refresh = 100;
+	inline int time_counter = 0;
+
+	app::Object_1__Array* RefreshEntList(app::Object_1__Array* ent,const char* className, const char* classNamespace = "");
+
 	void RunPlayersESP();
 	void RunGoatsESP();
 	void RunItemsESP();

--- a/user/hooks/hooks.cpp
+++ b/user/hooks/hooks.cpp
@@ -94,6 +94,11 @@ typedef void(__stdcall* TNolanBehaviour_Update)(app::NolanBehaviour*, MethodInfo
 TNolanBehaviour_Update oNolanBehaviour_Update = NULL;
 void __stdcall hNolanBehaviour_Update(app::NolanBehaviour* __this, MethodInfo* method) {
 
+	// TEMP FIX #60
+	if (SceneName() != "Menu") {
+		ESP::ents_goat = Object::FindObjectsOfType("GoatBehaviour", "");
+	}
+
 	if (settings::spoof_level && IsLocalPlayer(__this)) {
 		Misc::RankSpoofer(settings::new_level);
 	}
@@ -778,7 +783,21 @@ HRESULT __stdcall hookD3D11Present(IDXGISwapChain* pSwapChain, UINT SyncInterval
 
 		if (settings::azazel_esp && SceneName() != "Menu")
 			ESP::RunAzazelESP();
+
+		ESP::time_counter += 1;
+
+		if (ESP::time_counter > ESP::time_refresh) {
+			ESP::time_counter = 0;
+		}
 	}
+	if (!IsInGame() && SceneName() == "Menu") {
+		if (settings::item_esp) {
+			ESP::ents_azazel	= nullptr;
+			ESP::ents_item		= nullptr;
+			ESP::ents_goat		= nullptr;
+		}
+	}
+
 
 	ImGui::GetIO().MouseDrawCursor = open_menu;
 


### PR DESCRIPTION
This pull request addresses issue #60 by implementing a temporary fix to prevent random crashes related to the ESP feature during gameplay. The main changes include updates to esp.cpp and modifications in the hNolanBehaviour_Update hook.

# Changes Made:
## hNolanBehaviour_Update Hook:

1. Added a check to ensure the ESP functionality does not execute in the menu, if in game, update the goat list, in this way we prevent the error by invalid memory addresses.

## ESP.cpp Modifications:

1. Introduced a RefreshEntList function to manage entity lists and avoid accessing invalid memory. This function serves as an example and might be useful for future improvements.
2. Updated the RunAzazelESP function to refresh the Azazel entity list periodically, preventing crashes by ensuring the pointers are up-to-date.
3. Improved the RunItemsESP function to maintain a list of items and update it periodically, similar to the Azazel entity handling.

## ESP.h Update:

1. Introduced the follow variables to the namespace:

  - inline app::GameObject__Array* ents_azazel = NULL;     // OLD AZAZEL
  - inline app::Object_1__Array* ents_item;                          // OLD ITEM LIST
  - inline app::Object_1__Array* ents_goat;                          // REAL TIME GOAT FROM HOOK
  - inline int time_refresh = 100;
  - inline int time_counter = 0;


# Summary:
These changes aim to stabilize the ESP feature by managing entity lists more effectively and avoiding invalid memory accesses. The temporary fixes implemented will mitigate random crashes, especially during non-menu gameplay scenarios.

Please review these changes and let me know if there are any adjustments needed. Thank you!