### PR TITLE
Fix for ESP and Addition of New Functions

### DIFF
--- a/user/features/esp/esp.cpp
+++ b/user/features/esp/esp.cpp
@@ -137,37 +137,52 @@ void ESP::RunDemonESP() {
 
 	std::vector<std::string> demons_c = { "SurvivalDemonBehaviour", "SpiderBehaviour", "GhostBehaviour", "BoarBehaviour", "CorpseBehaviour" };
 
-	for (std::string& class_ : demons_c) {
-		if (SceneName() != "Menu")
-			return;
-		app::Object_1__Array* ents = Object::FindObjectsOfType(class_.c_str(), "");
-		if (ents == nullptr)
-			continue;
-
-		std::string name = class_;
-		string_replace(name, "Survival", "");
-		string_replace(name, "Behaviour", "");
-		ComputePositionAndDrawESP(ents, col, false, name);
+	// There's might be a better way to do it, but i'm lazy : )
+	if (name_demon == "N/A") {
+		for (std::string& class_ : demons_c) {
+			ents_demon = RefreshEntList(ents_demon, class_.c_str(), "");
+			if (ents_demon && ents_demon->max_length > 0) {
+				name_demon = class_;
+			}
+		}		
 	}
-}
+	else {
+		ents_demon = RefreshEntList(ents_demon, name_demon.c_str(), "");
+	}
+	
+	if (ents_demon == nullptr) return;
 
+	app::Object_1__Array* ents = ents_demon;
+	std::string name = name_demon;
+	string_replace(name, "Survival", "");
+	string_replace(name, "Behaviour", "");
+	ComputePositionAndDrawESP(ents, col, false, name);
+}
 
 void ESP::RunItemsESP() {
 	ImColor col = ImColor{ settings::item_esp_color[0], settings::item_esp_color[1], settings::item_esp_color[2], settings::item_esp_color[3] };
 
 	ents_item = RefreshEntList(ents_item, "SurvivalInteractable");
-	if (ents_item == nullptr) return;
+	if (ents_item != nullptr) {
 
-	app::Object_1__Array* ents = ents_item;
+		app::Object_1__Array* ents = ents_item;
 
 
-	if (ents != nullptr || !Object::IsNull(ents->vector[0])) {
-		ComputePositionAndDrawESP(ents, col, true);
+		if (ents != nullptr || !Object::IsNull(ents->vector[0])) {
+			ComputePositionAndDrawESP(ents, col, true);
+		}
 	}
 
-	if (SceneName() != "Menu")
-		return;
-	ents = Object::FindObjectsOfType("KeyBehaviour", "");
+	
+}
+
+void ESP::RunKeyESP() {
+	ImColor col = ImColor{ settings::key_esp_color[0], settings::key_esp_color[1], settings::key_esp_color[2], settings::key_esp_color[3] };
+
+	app::Object_1__Array* ents = ents_key;
+
+	if (ents_key == nullptr) return;
+
 	if (ents != nullptr || !Object::IsNull(ents->vector[0])) {
 		ComputePositionAndDrawESP(ents, col, false, "Key");
 	}

--- a/user/features/esp/esp.hpp
+++ b/user/features/esp/esp.hpp
@@ -8,7 +8,11 @@ namespace ESP {
 	// TEMP FIX #60
 	inline app::GameObject__Array* ents_azazel = NULL;
 	inline app::Object_1__Array* ents_item;
+	inline app::Object_1__Array* ents_key;
 	inline app::Object_1__Array* ents_goat;
+	inline app::Object_1__Array* ents_demon;
+
+	inline std::string name_demon = "N/A";
 
 	inline int time_refresh = 100;
 	inline int time_counter = 0;
@@ -18,6 +22,7 @@ namespace ESP {
 	void RunPlayersESP();
 	void RunGoatsESP();
 	void RunItemsESP();
+	void RunKeyESP();
 	void RunDemonESP();
 	void RunAzazelESP();
 }

--- a/user/features/menu.cpp
+++ b/user/features/menu.cpp
@@ -115,6 +115,18 @@ void DrawVisualsTab() {
 		ImGui::EndPopup();
 	}
 
+	ImGui::Checkbox("Keys ESP", &settings::key_esp);
+	ImGui::SameLine();
+	bool open_kcolor_popup = ImGui::ColorButton("kespcolor", ImVec4(settings::key_esp_color[0], settings::key_esp_color[1], settings::key_esp_color[2], settings::key_esp_color[3]));
+	if (open_kcolor_popup)
+	{
+		ImGui::OpenPopup("kesppop");
+	}
+	if (ImGui::BeginPopup("kesppop")) {
+		ImGui::ColorPicker4("Key ESP color", (float*)&settings::key_esp_color);
+		ImGui::EndPopup();
+	}
+
 	ImGui::Checkbox("Demon ESP", &settings::demon_esp);
 	ImGui::SameLine();
 	bool open_dcolor_popup = ImGui::ColorButton("despcolor", ImVec4(settings::demon_esp_color[0], settings::demon_esp_color[1], settings::demon_esp_color[2], settings::demon_esp_color[3]));

--- a/user/hooks/hooks.cpp
+++ b/user/hooks/hooks.cpp
@@ -97,6 +97,7 @@ void __stdcall hNolanBehaviour_Update(app::NolanBehaviour* __this, MethodInfo* m
 	// TEMP FIX #60
 	if (SceneName() != "Menu") {
 		ESP::ents_goat = Object::FindObjectsOfType("GoatBehaviour", "");
+		ESP::ents_key = Object::FindObjectsOfType("KeyInteractable", "");
 	}
 
 	if (settings::spoof_level && IsLocalPlayer(__this)) {
@@ -771,17 +772,20 @@ HRESULT __stdcall hookD3D11Present(IDXGISwapChain* pSwapChain, UINT SyncInterval
 	if (settings::player_esp)
 		ESP::RunPlayersESP();
 
-	if (IsInGame() && !IsSequencePlaying()) {
-		if (settings::goat_esp && SceneName() != "Menu")
+	if (IsInGame() && !IsSequencePlaying() && SceneName() != "Menu") {
+		if (settings::goat_esp)
 			ESP::RunGoatsESP();
 
-		if (settings::item_esp && SceneName() != "Menu")
+		if (settings::item_esp)
 			ESP::RunItemsESP();
+
+		if (settings::key_esp)
+			ESP::RunKeyESP();
 
 		if (settings::demon_esp)
 			ESP::RunDemonESP();
 
-		if (settings::azazel_esp && SceneName() != "Menu")
+		if (settings::azazel_esp)
 			ESP::RunAzazelESP();
 
 		ESP::time_counter += 1;
@@ -791,11 +795,23 @@ HRESULT __stdcall hookD3D11Present(IDXGISwapChain* pSwapChain, UINT SyncInterval
 		}
 	}
 	if (!IsInGame() && SceneName() == "Menu") {
-		if (settings::item_esp) {
-			ESP::ents_azazel	= nullptr;
-			ESP::ents_item		= nullptr;
-			ESP::ents_goat		= nullptr;
-		}
+		if (settings::item_esp)
+			ESP::ents_item = nullptr;
+
+		if (settings::goat_esp)
+			ESP::ents_goat = nullptr;
+
+		if (settings::azazel_esp)
+			ESP::ents_azazel = nullptr;
+
+		if (settings::key_esp)
+			ESP::ents_key = nullptr;
+
+		if (settings::demon_esp) {
+			ESP::ents_demon = nullptr;
+			ESP::name_demon = "N/A";
+		};
+
 	}
 
 

--- a/user/main.cpp
+++ b/user/main.cpp
@@ -23,7 +23,7 @@
 
 #include "players/players.h"
 
-#define CLIENT_VERSION "4.1"
+#define CLIENT_VERSION "4.2"
 
 // Set the name of your log file here
 extern const LPCWSTR LOG_FILE = L"DevourClient.txt";

--- a/user/settings/settings.cpp
+++ b/user/settings/settings.cpp
@@ -25,6 +25,8 @@ namespace settings {
 	float demon_esp_color[4] = { 255.f, 0, 0, 255.f };
 	bool goat_esp = false;
 	float goat_esp_color[4] = { 247.f, 156.f, 37.f, 255.f };
+	bool key_esp = false;
+	float key_esp_color[4] = { 251.f,225.f,104.f,255.f };
 
 	bool chat_spam = false;
 	std::string message = "deez nuts";

--- a/user/settings/settings.hpp
+++ b/user/settings/settings.hpp
@@ -29,6 +29,8 @@ namespace settings {
 	extern float demon_esp_color[4];
 	extern bool goat_esp;
 	extern float goat_esp_color[4];
+	extern bool key_esp;
+	extern float key_esp_color[4];
 	extern bool chat_spam;
 	extern std::string message;
 	extern bool spoof_level;


### PR DESCRIPTION
This pull request addresses to the fix of the ESP(i hope) and also add new functions.

# Changes Made:
## ESP.c:

1. RunDemonESP  : Now it verifies the variable "name_demon" if's not "N/A" our code will scan for all possible demons behaviour by the amount of GameObject in the scene.
2. RunItemsESP    : Removed the not used section to get the keys.
3. RunKeyESP       : New function to render all keys.

## ESP.h Update:

1. Introduced the follow variables to the namespace:

  - inline app::Object_1__Array* ents_key;       // All keys in scene, update in real-time.
  - inline app::Object_1__Array* ents_demon; // All demons.
  - inline std::string name_demon = "N/A"; // Used in FindObjectsOfType to get the demon behaviors.

## MENU.cpp:

1. Introduced new checkbox to enable KEY ESP

## HOOKS.cpp:
1. Introduced Object::FindObjectsOfType("KeyInteractable") to update the keys variables.
2. Changed the lines to reset the ESP off-match, preventing crashes in the next game round.

## Others:

- Various other minor adjustments.

# Summary:
These changes aim to completely fix the ESP problem and introduce new functionalities.

Please review these changes and let me know if there are any adjustments needed. Thank you!